### PR TITLE
Support arbitrary links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,9 @@
 import React from "react";
 import { useState, useEffect } from "react";
 import config from "./pages.json";
+import { SearchPane } from "./SearchPane.js";
 import styled from "styled-components";
-import { ChevronLeft, ChevronRight, Rewind, Search } from "@core-ds/icons/16";
-import Modal from "@material-ui/core/Modal";
-import Paper from "@material-ui/core/Paper";
+import { ChevronLeft, ChevronRight, Rewind } from "@core-ds/icons/16";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
@@ -66,72 +65,6 @@ function Page({ src, width }) {
       </PageLink>
       <PageFrame src={src} width={width} />
     </PageWrapper>
-  );
-}
-
-const ResultLink = styled.a`
-  display: block;
-  padding-bottom: 4px;
-`;
-
-const Scroller = styled.div`
-  width: 100%;
-  flex-grow: 1;
-  overflow: scroll;
-`;
-
-function Results({ search, close }) {
-  const re = new RegExp(search, "i");
-  return (
-    <Scroller>
-      {pages.map((page, idx) => {
-        if (re.test(page)) {
-          return (
-            <ResultLink onClick={close} href={`#${idx}`}>
-              {page}
-            </ResultLink>
-          );
-        }
-      })}
-    </Scroller>
-  );
-}
-
-const SearchDialog = styled(Paper)`
-  position: absolute;
-  width: max-content;
-  max-width: 80%;
-  max-height: 80%;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 16px;
-`;
-
-function SearchPane() {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const updateSearch = (evt) => {
-    setSearch(evt.target.value);
-  };
-  const closeModal = () => setOpen(false);
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>
-        <Search />
-      </Button>
-      <Modal open={open} onClose={closeModal}>
-        <SearchDialog>
-          <div>
-            <input type="text" autoFocus onChange={updateSearch}></input>
-          </div>
-          <Results close={closeModal} search={search} />
-        </SearchDialog>
-      </Modal>
-    </>
   );
 }
 
@@ -224,7 +157,7 @@ function App() {
             onChange={updateWidth}
             value={width}
           />
-          <SearchPane />
+          <SearchPane pages={pages} />
         </Controls>
       </Header>
       <Comparison>

--- a/src/App.js
+++ b/src/App.js
@@ -75,7 +75,7 @@ const getDefaultIdx = () => {
 };
 
 function App() {
-  const [idx, setIdx] = useState(getDefaultIdx);
+  const [idx, setIdxValue] = useState(getDefaultIdx);
   const [url, setUrl] = useState(
     getDefaultComparisonSource(default_comparison_source)
   );
@@ -84,7 +84,18 @@ function App() {
     window.addEventListener("hashchange", () => setIdx(getDefaultIdx));
   }, []);
   const urlPart = pages[idx];
-  const { original, updated } = getPageUrls(url, urlPart, comparison_target);
+  const { original, updated, targetDomain } = getPageUrls(
+    url,
+    urlPart,
+    comparison_target
+  );
+
+  const setIdx = (f) => {
+    if (targetDomain !== url) {
+      setUrl(targetDomain);
+    }
+    setIdxValue(f);
+  };
 
   const first = () => setIdx(0);
   const next = () => setIdx((idx) => (idx + 1 < pages.length ? idx + 1 : idx));

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { ChevronLeft, ChevronRight, Rewind } from "@core-ds/icons/16";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
-import { getComparisonTarget } from "./comparison_urls.js";
+import { getPageUrls } from "./comparison_urls.js";
 
 const { pages, comparison_target, default_comparison_source } = config;
 
@@ -104,17 +104,14 @@ function App() {
     setDomain(evt.target.value);
   };
   const urlPart = pages[idx];
-  const comparison = getComparisonTarget(domain, comparison_target);
-  const pageUrl = `https://${comparison}/${urlPart}`;
-  const updatedPageUrl = `https://${domain}/${urlPart}`;
-
+  const { original, updated } = getPageUrls(domain, urlPart, comparison_target);
   useEffect(() => {
     window.scroll({
       top: 0,
       left: 0,
       behavior: "smooth",
     });
-  }, [pageUrl, updatedPageUrl]);
+  }, [original, updated]);
   const [width, setWidth] = useState();
   const updateWidth = (evt) => {
     setWidth(evt.target.value);
@@ -154,8 +151,8 @@ function App() {
         </Controls>
       </Header>
       <Comparison>
-        <Page width={width} src={updatedPageUrl} />
-        <Page width={width} src={pageUrl} />
+        <Page width={width} src={updated} />
+        <Page width={width} src={original} />
       </Comparison>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,15 @@ import { useState, useEffect } from "react";
 import config from "./pages.json";
 import { SearchPane } from "./SearchPane.js";
 import styled from "styled-components";
-import { ChevronLeft, ChevronRight, Rewind } from "@core-ds/icons/16";
+import { ChevronLeft, ChevronRight, Rewind, Link } from "@core-ds/icons/16";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
-import { getPageUrls, getDefaultComparisonSource } from "./comparison_urls.js";
+import {
+  getPageUrls,
+  getDefaultComparisonSource,
+  setDefaultComparisonSource,
+} from "./comparison_urls.js";
 
 const { pages, comparison_target, default_comparison_source } = config;
 
@@ -115,10 +119,16 @@ function App() {
       behavior: "smooth",
     });
   }, [original, updated]);
+
   const [width, setWidth] = useState();
   const updateWidth = (evt) => {
     setWidth(evt.target.value);
   };
+
+  const updateComparisonSource = () => {
+    setDefaultComparisonSource(url);
+  };
+
   return (
     <div className="App">
       <Header>
@@ -142,6 +152,9 @@ function App() {
             onChange={updateUrl}
             value={url}
           />
+          <Button onClick={updateComparisonSource} title="Synchronize to URL">
+            <Link />
+          </Button>
           <TextField
             placeholder="Width"
             size="small"

--- a/src/App.js
+++ b/src/App.js
@@ -61,18 +61,19 @@ function Page({ src, width }) {
   );
 }
 
+const getDefaultIdx = () => {
+  const initPage = Number(window.location.hash.slice(1));
+  if (Number.isNaN(initPage)) {
+    return 0;
+  } else {
+    return initPage;
+  }
+};
+
 function App() {
-  const getIdx = () => {
-    const initPage = Number(window.location.hash.slice(1));
-    if (Number.isNaN(initPage)) {
-      return 0;
-    } else {
-      return initPage;
-    }
-  };
-  const [idx, setIdx] = useState(getIdx);
+  const [idx, setIdx] = useState(getDefaultIdx);
   useEffect(() => {
-    window.addEventListener("hashchange", () => setIdx(getIdx));
+    window.addEventListener("hashchange", () => setIdx(getDefaultIdx));
   }, []);
   const first = () => setIdx(0);
   const next = () => setIdx((idx) => (idx + 1 < pages.length ? idx + 1 : idx));

--- a/src/App.js
+++ b/src/App.js
@@ -97,14 +97,14 @@ function App() {
   useEffect(() => {
     document.addEventListener("keyup", keyHandler);
   }, []);
-  const [domain, setDomain] = useState(
+  const [url, setUrl] = useState(
     getDefaultComparisonSource(default_comparison_source)
   );
   const updateUrl = (evt) => {
-    setDomain(evt.target.value);
+    setUrl(evt.target.value);
   };
   const urlPart = pages[idx];
-  const { original, updated } = getPageUrls(domain, urlPart, comparison_target);
+  const { original, updated } = getPageUrls(url, urlPart, comparison_target);
   useEffect(() => {
     window.scroll({
       top: 0,
@@ -137,7 +137,7 @@ function App() {
             size="small"
             type="text"
             onChange={updateUrl}
-            value={domain}
+            value={url}
           />
           <TextField
             placeholder="Width"

--- a/src/App.js
+++ b/src/App.js
@@ -104,7 +104,7 @@ function App() {
     setDomain(evt.target.value);
   };
   const urlPart = pages[idx];
-  const comparison = getComparisonTarget(domain);
+  const comparison = getComparisonTarget(domain, comparison_target);
   const pageUrl = `https://${comparison}/${urlPart}`;
   const updatedPageUrl = `https://${domain}/${urlPart}`;
 

--- a/src/App.js
+++ b/src/App.js
@@ -79,6 +79,9 @@ function App() {
   useEffect(() => {
     window.addEventListener("hashchange", () => setIdx(getDefaultIdx));
   }, []);
+  const urlPart = pages[idx];
+  const { original, updated } = getPageUrls(url, urlPart, comparison_target);
+
   const first = () => setIdx(0);
   const next = () => setIdx((idx) => (idx + 1 < pages.length ? idx + 1 : idx));
   const prev = () => setIdx((idx) => (idx > 0 ? idx - 1 : idx));
@@ -105,8 +108,6 @@ function App() {
   const updateUrl = (evt) => {
     setUrl(evt.target.value);
   };
-  const urlPart = pages[idx];
-  const { original, updated } = getPageUrls(url, urlPart, comparison_target);
   useEffect(() => {
     window.scroll({
       top: 0,

--- a/src/App.js
+++ b/src/App.js
@@ -72,6 +72,10 @@ const getDefaultIdx = () => {
 
 function App() {
   const [idx, setIdx] = useState(getDefaultIdx);
+  const [url, setUrl] = useState(
+    getDefaultComparisonSource(default_comparison_source)
+  );
+
   useEffect(() => {
     window.addEventListener("hashchange", () => setIdx(getDefaultIdx));
   }, []);
@@ -98,9 +102,6 @@ function App() {
   useEffect(() => {
     document.addEventListener("keyup", keyHandler);
   }, []);
-  const [url, setUrl] = useState(
-    getDefaultComparisonSource(default_comparison_source)
-  );
   const updateUrl = (evt) => {
     setUrl(evt.target.value);
   };

--- a/src/App.js
+++ b/src/App.js
@@ -7,16 +7,9 @@ import { ChevronLeft, ChevronRight, Rewind } from "@core-ds/icons/16";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
+import { getComparisonTarget } from "./comparison_urls.js";
 
 const { pages, comparison_target, default_comparison_source } = config;
-function getComparisonTarget(domain) {
-  const parts = domain.split(".");
-  if (parts.length > 3) {
-    const subdomain = parts.slice(0, -3).join(".");
-    return `${subdomain}.${comparison_target}`;
-  }
-  return comparison_target;
-}
 
 const Controls = styled.div`
   display: flex;

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { ChevronLeft, ChevronRight, Rewind } from "@core-ds/icons/16";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
-import { getPageUrls } from "./comparison_urls.js";
+import { getPageUrls, getDefaultComparisonSource } from "./comparison_urls.js";
 
 const { pages, comparison_target, default_comparison_source } = config;
 
@@ -98,7 +98,7 @@ function App() {
     document.addEventListener("keyup", keyHandler);
   }, []);
   const [domain, setDomain] = useState(
-    default_comparison_source || window.location.host
+    getDefaultComparisonSource(default_comparison_source)
   );
   const updateUrl = (evt) => {
     setDomain(evt.target.value);

--- a/src/App.js
+++ b/src/App.js
@@ -148,13 +148,13 @@ function App() {
           value={(100 * (idx + 1)) / pages.length}
         />
         <Controls>
-          <Button onClick={first}>
+          <Button onClick={first} title="First">
             <Rewind />
           </Button>
-          <Button onClick={prev}>
+          <Button onClick={prev} title="Previous">
             <ChevronLeft />
           </Button>
-          <Button onClick={next}>
+          <Button onClick={next} title="Next">
             <ChevronRight />
           </Button>
           <TextField
@@ -162,6 +162,7 @@ function App() {
             type="text"
             onChange={updateUrl}
             value={url}
+            title="Target URL"
           />
           <Button onClick={updateComparisonSource} title="Synchronize to URL">
             <Link />
@@ -173,6 +174,7 @@ function App() {
             type="numeric"
             onChange={updateWidth}
             value={width}
+            title="Width"
           />
           <SearchPane pages={pages} />
         </Controls>

--- a/src/SearchPane.js
+++ b/src/SearchPane.js
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import Modal from "@material-ui/core/Modal";
+import Paper from "@material-ui/core/Paper";
+import Button from "@material-ui/core/Button";
+import { Search } from "@core-ds/icons/16";
+import styled from "styled-components";
+
+export function SearchPane({ pages }) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const updateSearch = (evt) => {
+    setSearch(evt.target.value);
+  };
+  const closeModal = () => setOpen(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <Search />
+      </Button>
+      <Modal open={open} onClose={closeModal}>
+        <SearchDialog>
+          <div>
+            <input type="text" autoFocus onChange={updateSearch}></input>
+          </div>
+          <Results close={closeModal} search={search} pages={pages} />
+        </SearchDialog>
+      </Modal>
+    </>
+  );
+}
+
+function Results({ search, close, pages }) {
+  const re = new RegExp(search, "i");
+  return (
+    <Scroller>
+      {pages.map((page, idx) => {
+        if (re.test(page)) {
+          return (
+            <ResultLink onClick={close} href={`#${idx}`}>
+              {page}
+            </ResultLink>
+          );
+        }
+      })}
+    </Scroller>
+  );
+}
+
+const SearchDialog = styled(Paper)`
+  position: absolute;
+  width: max-content;
+  max-width: 80%;
+  max-height: 80%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+`;
+
+const Scroller = styled.div`
+  width: 100%;
+  flex-grow: 1;
+  overflow: scroll;
+`;
+
+const ResultLink = styled.a`
+  display: block;
+  padding-bottom: 4px;
+`;

--- a/src/SearchPane.js
+++ b/src/SearchPane.js
@@ -14,7 +14,7 @@ export function SearchPane({ pages }) {
   const closeModal = () => setOpen(false);
   return (
     <>
-      <Button onClick={() => setOpen(true)}>
+      <Button onClick={() => setOpen(true)} title="Find URL">
         <Search />
       </Button>
       <Modal open={open} onClose={closeModal}>

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -19,5 +19,10 @@ export function getPageUrls(domain, urlPart, comparisonTarget) {
 }
 
 export function getDefaultComparisonSource(defaultComparisonSource) {
-  return defaultComparisonSource || window.location.host;
+  const url = new URL(window.location);
+  if (url.searchParams.has("target")) {
+    return url.searchParams.get("target");
+  }
+  return defaultComparisonSource || url.host;
+}
 }

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -6,3 +6,10 @@ export function getComparisonTarget(domain, comparisonTarget) {
   }
   return comparisonTarget;
 }
+
+export function getPageUrls(domain, urlPart, comparisonTarget) {
+  const comparison = getComparisonTarget(domain, comparisonTarget);
+  const pageUrl = `https://${comparison}/${urlPart}`;
+  const updatedPageUrl = `https://${domain}/${urlPart}`;
+  return { original: pageUrl, updated: updatedPageUrl };
+}

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -1,4 +1,4 @@
-export function getComparisonTarget(domain, comparisonTarget) {
+function getComparisonTarget(domain, comparisonTarget) {
   const parts = domain.split(".");
   if (parts.length > 3) {
     const subdomain = parts.slice(0, -3).join(".");

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -7,14 +7,14 @@ function getComparisonTarget(domain, comparisonTarget) {
   return comparisonTarget;
 }
 
-export function getPageUrls(domain, urlPart, comparisonTarget) {
-  const comparison = getComparisonTarget(domain, comparisonTarget);
+export function getPageUrls(url, urlPart, comparisonTarget) {
+  const comparison = getComparisonTarget(url, comparisonTarget);
   const pageUrl = `https://${comparison}/${urlPart}`;
-  const updatedPageUrl = `https://${domain}/${urlPart}`;
+  const updatedPageUrl = `https://${url}/${urlPart}`;
   return {
     original: pageUrl,
     updated: updatedPageUrl,
-    targetDomain: domain,
+    targetDomain: url,
   };
 }
 

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -8,14 +8,30 @@ function getComparisonTarget(domain, comparisonTarget) {
 }
 
 export function getPageUrls(url, urlPart, comparisonTarget) {
-  const comparison = getComparisonTarget(url, comparisonTarget);
-  const pageUrl = `https://${comparison}/${urlPart}`;
-  const updatedPageUrl = `https://${url}/${urlPart}`;
+  const { host, path } = splitUrl(url);
+  const comparison = getComparisonTarget(host, comparisonTarget);
+  const pageUrl = formatUrl(comparison, path || urlPart);
+  const updatedPageUrl = formatUrl(host, path || urlPart);
   return {
     original: pageUrl,
     updated: updatedPageUrl,
-    targetDomain: url,
+    targetDomain: host,
   };
+}
+
+function splitUrl(url) {
+  const idx = url.indexOf("/");
+  if (idx < 0) {
+    return { host: url, path: null };
+  }
+  return {
+    host: url.slice(0, idx),
+    path: url.slice(idx + 1),
+  };
+}
+
+function formatUrl(host, path) {
+  return `https://${host}/${path}`;
 }
 
 export function getDefaultComparisonSource(defaultComparisonSource) {

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -13,3 +13,7 @@ export function getPageUrls(domain, urlPart, comparisonTarget) {
   const updatedPageUrl = `https://${domain}/${urlPart}`;
   return { original: pageUrl, updated: updatedPageUrl };
 }
+
+export function getDefaultComparisonSource(defaultComparisonSource) {
+  return defaultComparisonSource || window.location.host;
+}

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -1,11 +1,8 @@
-import config from "./pages.json";
-const { pages, comparison_target, default_comparison_source } = config;
-
-export function getComparisonTarget(domain) {
+export function getComparisonTarget(domain, comparisonTarget) {
   const parts = domain.split(".");
   if (parts.length > 3) {
     const subdomain = parts.slice(0, -3).join(".");
-    return `${subdomain}.${comparison_target}`;
+    return `${subdomain}.${comparisonTarget}`;
   }
-  return comparison_target;
+  return comparisonTarget;
 }

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -1,0 +1,11 @@
+import config from "./pages.json";
+const { pages, comparison_target, default_comparison_source } = config;
+
+export function getComparisonTarget(domain) {
+  const parts = domain.split(".");
+  if (parts.length > 3) {
+    const subdomain = parts.slice(0, -3).join(".");
+    return `${subdomain}.${comparison_target}`;
+  }
+  return comparison_target;
+}

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -41,4 +41,9 @@ export function getDefaultComparisonSource(defaultComparisonSource) {
   }
   return defaultComparisonSource || url.host;
 }
+
+export function setDefaultComparisonSource(value) {
+  const url = new URL(window.location);
+  url.searchParams.set("target", value);
+  window.history.pushState(null, "", url.toString());
 }

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -11,7 +11,11 @@ export function getPageUrls(domain, urlPart, comparisonTarget) {
   const comparison = getComparisonTarget(domain, comparisonTarget);
   const pageUrl = `https://${comparison}/${urlPart}`;
   const updatedPageUrl = `https://${domain}/${urlPart}`;
-  return { original: pageUrl, updated: updatedPageUrl };
+  return {
+    original: pageUrl,
+    updated: updatedPageUrl,
+    targetDomain: domain,
+  };
 }
 
 export function getDefaultComparisonSource(defaultComparisonSource) {


### PR DESCRIPTION
We now have the option to provide a path on the URL in the target box. This allows us to look at paths not in the standard list of URLs:
![image](https://user-images.githubusercontent.com/1283490/81319373-6b43c200-9044-11ea-85dc-5163b78c0aa6.png)

This pull also adds support for setting the contents of the target box from a URL parameter, which enables us to send links to various URLs.