### PR TITLE
Auto scale iframes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -131,7 +131,7 @@ function App() {
     });
   }, [original, updated]);
 
-  const [width, setWidth] = useState();
+  const [width, setWidth] = useState("");
   const updateWidth = (evt) => {
     setWidth(evt.target.value);
   };

--- a/src/App.js
+++ b/src/App.js
@@ -36,10 +36,37 @@ const Comparison = styled.div`
   display: flex;
 `;
 
-const PageFrame = styled.iframe`
+function getScale(width) {
+  const maxWidth = (window.innerWidth - 20) / 2;
+  if (width > maxWidth) {
+    return `scale(calc(${maxWidth}/${width}))`;
+  } else {
+    return null;
+  }
+}
+
+const BasePageFrame = styled.iframe`
   height: 5000px;
-  width: ${(props) => props.width || "100%"};
 `;
+
+const FitPageFrame = styled(BasePageFrame)`
+  width: 100%;
+`;
+
+const ScaledPageFrame = styled(BasePageFrame)`
+  width: ${(props) => props.width};
+  transform: ${(props) => getScale(props.width)};
+  transform-origin: top left;
+  position: absolute;
+`;
+
+const PageFrame = ({ width, ...props }) => {
+  if (width) {
+    return <ScaledPageFrame width={width} {...props} />;
+  } else {
+    return <FitPageFrame width={width} {...props} />;
+  }
+};
 
 const PageLink = styled.div`
   overflow: hidden;


### PR DESCRIPTION
When we set a width value, we used to just set the width on the iframes:
![image](https://user-images.githubusercontent.com/1283490/81437948-ca770480-9120-11ea-95b5-3204c4f5bf3e.png)
But this results in a very wide page which is hard to work with. The value of Jux is that it allows us to see two pages side by side. So let's use CSS scaling to allow us to fit two larger width iframes scaled down in the one window:
![image](https://user-images.githubusercontent.com/1283490/81440407-db297980-9124-11ea-80d2-87aece45618d.png)