### PR TITLE
Persistent width

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,8 @@ import {
   getPageUrls,
   getDefaultComparisonSource,
   setDefaultComparisonSource,
+  getDefaultWidth,
+  setDefaultWidth,
 } from "./comparison_urls.js";
 
 const { pages, comparison_target, default_comparison_source } = config;
@@ -158,13 +160,14 @@ function App() {
     });
   }, [original, updated]);
 
-  const [width, setWidth] = useState("");
+  const [width, setWidth] = useState(getDefaultWidth() || "");
   const updateWidth = (evt) => {
     setWidth(evt.target.value);
   };
 
   const updateComparisonSource = () => {
     setDefaultComparisonSource(url);
+    setDefaultWidth(width);
   };
 
   return (

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -43,6 +43,15 @@ export function setDefaultComparisonSource(value) {
   setSearchParam("target", value);
 }
 
+const WIDTH_PARAM = "width";
+export function getDefaultWidth() {
+  return getSearchParam(WIDTH_PARAM);
+}
+
+export function setDefaultWidth(value) {
+  setSearchParam(WIDTH_PARAM, value);
+}
+
 function getSearchParam(key) {
   const url = new URL(window.location);
   return url.searchParams.get(key);

--- a/src/comparison_urls.js
+++ b/src/comparison_urls.js
@@ -35,15 +35,21 @@ function formatUrl(host, path) {
 }
 
 export function getDefaultComparisonSource(defaultComparisonSource) {
-  const url = new URL(window.location);
-  if (url.searchParams.has("target")) {
-    return url.searchParams.get("target");
-  }
-  return defaultComparisonSource || url.host;
+  const target = getSearchParam("target");
+  return target || defaultComparisonSource || window.location.host;
 }
 
 export function setDefaultComparisonSource(value) {
+  setSearchParam("target", value);
+}
+
+function getSearchParam(key) {
   const url = new URL(window.location);
-  url.searchParams.set("target", value);
+  return url.searchParams.get(key);
+}
+
+function setSearchParam(key, value) {
+  const url = new URL(window.location);
+  url.searchParams.set(key, value);
   window.history.pushState(null, "", url.toString());
 }


### PR DESCRIPTION
Allow `width` to be set via `GET` parameter.
This allows the user to refresh the page without loosing the page width they're working with.