### PR TITLE
Fix background color

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -102,6 +102,7 @@ function Page({ src, width }) {
 
 const DiffBasePageFrame = styled(BasePageFrame)`
   position: absolute;
+  background: white;
 `;
 
 const DiffFitPageFrame = styled(DiffBasePageFrame)`

--- a/src/Preferences.js
+++ b/src/Preferences.js
@@ -57,7 +57,7 @@ function PreferencesDrawer({ open, onClose, setData }) {
         <Typography variant="h5">Preferences</Typography>
         <List>
           <ListItem>
-            <TextField autoFocus name="width" label="Width" />
+            <TextField name="width" label="Width" />
           </ListItem>
           <ListItem>
             <Switch name="diff" label="Diff Mode" />


### PR DESCRIPTION
This makes diff mode go completely black when there are no differences.

It also stops autofocusing the width field in the preferences, which makes it less annoying to enable diff mode.